### PR TITLE
Spellcheck

### DIFF
--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -901,14 +901,14 @@ If the file argument is a handle (if it is a ref and is an IO or GLOB
 object), then that handle is slurped in. This mode is supported so you
 slurp handles such as C<DATA> and C<STDIN>. See the test handle.t for
 an example that does C<open( '-|' )> and the child process spews data
-to the parant which slurps it in.  All of the options that control how
+to the parent which slurps it in.  All of the options that control how
 the data is returned to the caller still work in this case.
 
 If the first argument is an overloaded object then its stringified value
 is used for the filename and that file is opened.  This is a new feature
 in 9999.14. See the stringify.t test for an example.
 
-By default C<read_file> returns an undef in scalar contex or a single
+By default C<read_file> returns an undef in scalar context or a single
 undef in list context if it encounters an error. Those are both
 impossible to get with a clean read_file call which means you can check
 the return value and always know if you had an error. You can change how
@@ -1148,7 +1148,7 @@ data to be written to the file and that is passed to C<write_file> as is
 
 Only the C<binmode> and C<err_mode> options are supported. The
 C<write_file> call has the C<atomic> option set so you will always have
-a consistant file. See above for more about those options.
+a consistent file. See above for more about those options.
 
 C<prepend_file> is not exported by default, you need to import it
 explicitly.
@@ -1184,7 +1184,7 @@ C<prepend_file>.
 
 Only the C<binmode> and C<err_mode> options are supported. The
 C<write_file> call has the C<atomic> option set so you will always
-have a consistant file. See above for more about those options.
+have a consistent file. See above for more about those options.
 
 Each group of calls below show a Perl command line instance and the
 equivalent calls to C<edit_file> and C<edit_file_lines>.
@@ -1237,7 +1237,7 @@ list of files.
 If this boolean option is set, the string "$dir/" is prefixed to each
 dir entry. This means you can directly use the results to open
 files. A common newbie mistake is not putting the directory in front
-of entries when opening themn.
+of entries when opening them.
 
 	my @paths = read_dir( '/path/to/dir', prefix => 1 ) ;
 

--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -25,12 +25,12 @@ my @std_export = qw(
 	read_dir
 ) ;
 
-my @edit_export = qw( 
+my @edit_export = qw(
 	edit_file
 	edit_file_lines
 ) ;
 
-my @ok_export = qw( 
+my @ok_export = qw(
 ) ;
 
 my @abbrev_export = qw(
@@ -555,7 +555,7 @@ sub write_file {
 	return 1 ;
 }
 
-# this is for backwards compatibility with the previous File::Slurp module. 
+# this is for backwards compatibility with the previous File::Slurp module.
 # write_file always overwrites an existing file
 
 *overwrite_file = \&write_file ;
@@ -854,7 +854,7 @@ File::Slurp - Simple and Efficient Reading/Writing/Modifying of Complete Files
 # insert text at the beginning of a file
   prepend_file( 'filename', $text ) ;
 
-# in-place edit to replace all 'foo' with 'bar' in file 
+# in-place edit to replace all 'foo' with 'bar' in file
   edit_file { s/foo/bar/g } 'filename' ;
 
 # in-place edit to delete all lines with 'foo' from file
@@ -1180,7 +1180,7 @@ block or a code reference. The code block is not followed by a comma
 comma. See the examples below for both styles. The next argument is
 the filename. The last argument is an optional hash reference and it
 contains key/values that can modify the behavior of
-C<prepend_file>. 
+C<prepend_file>.
 
 Only the C<binmode> and C<err_mode> options are supported. The
 C<write_file> call has the C<atomic> option set so you will always
@@ -1253,7 +1253,7 @@ of entries when opening themn.
 
   edit_file edit_file_lines
 
-  You can get all subs in the module exported with 
+  You can get all subs in the module exported with
 	use File::Slurp qw( :all ) ;
 
 =head2 LICENSE


### PR DESCRIPTION
Two commits. They should probably have been squashed, but given that one was simply whitespace changes (line endings) I wanted it to remain separated so you could easily see the diff on the typo fixes.

This pull request touches no code!

It only alters Slurp.pm to fix a few typos (only a couple) and to trim lines so that there are no trailing spaces. The reason for the latter is that hopefully later we can agree on some automated tests that help us ensure a clean release with things like:

* [Test::Spelling](https://metacpan.org/pod/Test::Spelling)
* [Test::EOL](https://metacpan.org/pod/Test::EOL)
* [Test::NoTabs](https://metacpan.org/pod/Test::NoTabs)
* [Test::Mojibake](https://metacpan.org/pod/Test::Mojibake)
* etc.

These types of tests don't do anything other than provide module authors with some extra help to ensure a clean(er) release is made. They wouldn't actually be run at install time on the user's end or anything like that.