### PR TITLE
Kid51 prepend file 20180927

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ File-Slurp.*
 pm_to_blib
 MYMETA.*
 newline.txt
+*.swp
+cover_db/

--- a/MANIFEST
+++ b/MANIFEST
@@ -9,6 +9,7 @@ t/append_null.t
 t/binmode.t
 t/data_list.t
 t/data_scalar.t
+t/edit_file.t
 t/error.t
 t/error_mode.t
 t/file_object.t

--- a/t/edit_file.t
+++ b/t/edit_file.t
@@ -1,0 +1,119 @@
+
+use strict ;
+use warnings ;
+
+use lib qw(t) ;
+
+use File::Slurp qw( read_file write_file edit_file ) ;
+use Test::More ;
+
+use TestDriver ;
+
+my $file = 'edit_file' ;
+my $existing_data = <<PRE ;
+line 1
+line 2
+more
+PRE
+
+my $tests = [
+    {
+		name	=> 'edit line',
+		sub	=> \&edit_file,
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			$test->{args} = [
+				sub { s/([0-9])/${1}000/g },
+				$file,
+			] ;
+			$test->{expected} = join("\n" => (
+                'line 1000',
+                'line 2000',
+                'more',
+            ) ) . "\n";
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+    {
+		name	=> 'edit line; empty options hashref',
+		sub	=> \&edit_file,
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			$test->{args} = [
+				sub { s/([0-9])/${1}000/g },
+				$file,
+                {},
+			] ;
+			$test->{expected} = join("\n" => (
+                'line 1000',
+                'line 2000',
+                'more',
+            ) ) . "\n";
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+    {
+		name	=> 'edit line; invalid options',
+		sub	=> \&edit_file,
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			$test->{args} = [
+				sub { s/([0-9])/${1}000/g },
+				$file,
+                { foo => 1, bar => 0 },
+			] ;
+			$test->{expected} = join("\n" => (
+                'line 1000',
+                'line 2000',
+                'more',
+            ) ) . "\n";
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+    {
+		name	=> 'edit line; invalid options; binmode',
+		sub	=> \&edit_file,
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			$test->{args} = [
+				sub { s/([0-9])/${1}000/g },
+				$file,
+                { foo => 1, bar => 0, binmode => ':raw' },
+			] ;
+			$test->{expected} = join("\n" => (
+                'line 1000',
+                'line 2000',
+                'more',
+            ) ) . "\n";
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+    {
+		name	=> 'edit line; invalid options; err_mode',
+		sub	=> \&edit_file,
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			$test->{args} = [
+				sub { s/([0-9])/${1}000/g },
+				$file,
+                { foo => 1, bar => 0, err_mode => 'quiet' },
+			] ;
+			$test->{expected} = join("\n" => (
+                'line 1000',
+                'line 2000',
+                'more',
+            ) ) . "\n";
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+] ;
+
+test_driver( $tests ) ;
+unlink $file ;
+
+exit ;

--- a/t/prepend_file.t
+++ b/t/prepend_file.t
@@ -65,6 +65,90 @@ my $tests = [
 		},
 		posttest => sub { $_[0]->{result} = read_file( $file ) },
 	},
+	{
+		name	=> 'prepend line; empty options hashref',
+		sub	=> \&prepend_file,
+		prepend_data => "line 0\n",
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			my $prepend_data = $test->{prepend_data} ;
+			$test->{args} = [
+				$file,
+                {},
+				$prepend_data,
+			] ;
+			$test->{expected} = "$prepend_data$existing_data" ;
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+	{
+		name	=> 'prepend line; invalid options',
+		sub	=> \&prepend_file,
+		prepend_data => "line 0\n",
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			my $prepend_data = $test->{prepend_data} ;
+			$test->{args} = [
+				$file,
+                { foo => 1, bar => 0 },
+				$prepend_data,
+			] ;
+			$test->{expected} = "$prepend_data$existing_data" ;
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+	{
+		name	=> 'prepend line; invalid options; binmode',
+		sub	=> \&prepend_file,
+		prepend_data => "line 0\n",
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			my $prepend_data = $test->{prepend_data} ;
+			$test->{args} = [
+				$file,
+                { foo => 1, bar => 0, binmode => ':raw' },
+				$prepend_data,
+			] ;
+			$test->{expected} = "$prepend_data$existing_data" ;
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+	{
+		name	=> 'prepend line; invalid options; err_mode',
+		sub	=> \&prepend_file,
+		prepend_data => "line 0\n",
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			my $prepend_data = $test->{prepend_data} ;
+			$test->{args} = [
+				$file,
+                { foo => 1, bar => 0, err_mode => 'quiet' },
+				$prepend_data,
+			] ;
+			$test->{expected} = "$prepend_data$existing_data" ;
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
+	{
+		name	=> 'prepend line: text in ref to scalar',
+		sub	=> \&prepend_file,
+		prepend_data => "line 0\n",
+		pretest	=> sub {
+			my( $test ) = @_ ;
+			write_file( $file, $existing_data ) ;
+			my $prepend_data = $test->{prepend_data} ;
+			$test->{args} = [
+				$file,
+				\$prepend_data,
+			] ;
+			$test->{expected} = "$prepend_data$existing_data" ;
+		},
+		posttest => sub { $_[0]->{result} = read_file( $file ) },
+	},
 ] ;
 
 test_driver( $tests ) ;


### PR DESCRIPTION
The purpose of this pull request is to improve the coverage of File::Slurp's source code by its test suite.  Additional tests are added to the existing file covering ```prepend_file()``` and a new file is added to cover ```edit_file()```.  This improves the test coverage (as measured by Devel::Cover) as follows:
```
uri-upstream/master (perhunter master)

----------------------------------- ------ ------ ------ ------ ------ ------
File                                  stmt   bran   cond    sub   time  total
----------------------------------- ------ ------ ------ ------ ------ ------
blib/lib/File/Slurp.pm                83.7   80.1   66.0  100.0  100.0   81.5
Total                                 83.7   80.1   66.0  100.0  100.0   81.5
----------------------------------- ------ ------ ------ ------ ------ ------


kid51-prepend-file-20180927

----------------------------------- ------ ------ ------ ------ ------ ------
File                                  stmt   bran   cond    sub   time  total
----------------------------------- ------ ------ ------ ------ ------ ------
blib/lib/File/Slurp.pm                84.3   82.6   77.3  100.0  100.0   83.8
Total                                 84.3   82.6   77.3  100.0  100.0   83.8
----------------------------------- ------ ------ ------ ------ ------ ------
```
Thank you very much.