### PR TITLE
Update build to accommodate older test harness and EUMM setting $^W

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,8 @@
 Revision history File::Slurp
 
 9999.20_03     2018-10-04  (TRIAL)
-	-
+	- Unset $^W in a few strategic places to silence warnings when Test::Harness
+	  or ExtUtils::MakeMaker turn them on. (Thanks, Graham Knop).
 
 9999.20_02     2018-10-04  (TRIAL)
 	- Update TravisCI tests to show coverage.

--- a/t/01-error_prepend_file.t
+++ b/t/01-error_prepend_file.t
@@ -12,6 +12,10 @@ use Test::More;
 
 plan tests => 27;
 
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
+
 # prepend_file reads in a file, edits the contents, writes the new file
 # atomically to "foo.$$" then renames "foo.$$" to the original "foo"
 # this leaves many failure steps to tend to

--- a/t/binmode.t
+++ b/t/binmode.t
@@ -12,6 +12,11 @@ BEGIN {
     plan skip_all => 'Older Perl lacking unicode support' if $] < 5.008001;
 }
 
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
+
+
 plan tests => 4;
 
 my $suf = 'utf8';

--- a/t/error.t
+++ b/t/error.t
@@ -13,6 +13,9 @@ use Test::More;
 plan tests => 30;
 
 my $is_win32 = $^O =~ /cygwin|win32/i ;
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
 
 # write_file open error - no sysopen
 {

--- a/t/large.t
+++ b/t/large.t
@@ -7,6 +7,10 @@ use File::Slurp;
 use File::Temp qw(tempfile);
 use Test::More;
 
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
+
 my @text_data = (
     [],
     [ 'a' x 8 ],

--- a/t/lib/FileSlurpTest.pm
+++ b/t/lib/FileSlurpTest.pm
@@ -23,9 +23,13 @@ sub IS_WSL() {
 sub temp_file_path {
     my ($pick_nonsense_path) = @_;
 
+    # older EUMMs turn this on. We don't want to emit warnings.
+    # also, some of our CORE function overrides emit warnings. Silence those.
+    local $^W;
+
     my $file;
     if ($pick_nonsense_path) {
-        $file = File::Spec->catfile(File::Spec->tmpdir, 'super', 'bad', 'file-spec', 'path');
+        $file = File::Spec->catfile(File::Spec->tmpdir, 'super', 'bad', 'file-slurp', 'path');
     }
     else {
         (undef, $file) = tempfile('tempXXXXX', DIR => File::Spec->tmpdir, OPEN => 0);

--- a/t/lib/FileSlurpTestOverride.pm
+++ b/t/lib/FileSlurpTestOverride.pm
@@ -2,6 +2,10 @@ package FileSlurpTestOverride;
 
 use Exporter qw(import);
 
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
+
 BEGIN {
     *CORE::GLOBAL::rename = sub($$) { my ($o, $n) = @_; CORE::rename($o, $n) };
     # we only use the 4-arg version of syswrite

--- a/t/original.t
+++ b/t/original.t
@@ -8,6 +8,10 @@ use Test::More;
 
 plan(tests => 8);
 
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
+
 my (undef, $tmp) = tempfile('tempXXXXX', DIR => File::Spec->tmpdir, OPEN => 0);
 
 my $short = <<END;

--- a/t/stringify.t
+++ b/t/stringify.t
@@ -7,6 +7,10 @@ use File::Temp qw(tempfile);
 use IO::Handle ();
 use Test::More;
 
+# older EUMMs turn this on. We don't want to emit warnings.
+# also, some of our CORE function overrides emit warnings. Silence those.
+local $^W;
+
 # this code creates the object which has a stringified path
 {
     package FileObject;


### PR DESCRIPTION
As can be seen on this [CPAN Testers Report](http://www.cpantesters.org/cpan/report/440e3ac8-caeb-11e8-bc28-1fcf7247484a) a few things emit warnings because older versions of ExtUtils::MakeMaker and Test::Harness turn on `$^W`.

File::Temp emits warnings if `$^W` is set when we use the `OPEN=>0` option.
Also, overriding some `CORE::` functions emit warnings due to 3-vs-4 arg differences in the calls.

Turning off these warnings in a few strategic places keeps them from blowing up our test suite since we actually need to test that warnings are emitted under certain `ERR_MODE` options.
