### PR TITLE
Remove work-arounds for undefined functions on old Perls.

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history File::Slurp
 	- Document each function with proper POD heads and re-order in alphabetical
 	- Dump the POD to GH markdown for a README.md
 	- Remove the README file
+	- Remove some work-arounds for older Perls < 5.6
 
 9999.21    2018-10-08
 	- Unset $^W in a few strategic places to silence warnings when Test::Harness

--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -62,55 +62,6 @@ my $max_fast_slurp_size = 1024 * 100 ;
 
 my $is_win32 = $^O =~ /win32/i ;
 
-# Install subs for various constants that aren't set in older perls
-# (< 5.005).  Fcntl on old perls uses Exporter to define subs without a
-# () prototype These can't be overridden with the constant pragma or
-# we get a prototype mismatch.  Hence this less than aesthetically
-# appealing BEGIN block:
-
-BEGIN {
-	unless( defined &SEEK_SET ) {
-		*SEEK_SET = sub { 0 };
-		*SEEK_CUR = sub { 1 };
-		*SEEK_END = sub { 2 };
-	}
-
-	unless( defined &O_BINARY ) {
-		*O_BINARY = sub { 0 };
-		*O_RDONLY = sub { 0 };
-		*O_WRONLY = sub { 1 };
-	}
-
-	unless ( defined &O_APPEND ) {
-
-		if ( $^O =~ /olaris/ ) {
-			*O_APPEND = sub { 8 };
-			*O_CREAT = sub { 256 };
-			*O_EXCL = sub { 1024 };
-		}
-		elsif ( $^O =~ /inux/ ) {
-			*O_APPEND = sub { 1024 };
-			*O_CREAT = sub { 64 };
-			*O_EXCL = sub { 128 };
-		}
-		elsif ( $^O =~ /BSD/i ) {
-			*O_APPEND = sub { 8 };
-			*O_CREAT = sub { 512 };
-			*O_EXCL = sub { 2048 };
-		}
-	}
-}
-
-# print "OS [$^O]\n" ;
-
-# print "O_BINARY = ", O_BINARY(), "\n" ;
-# print "O_RDONLY = ", O_RDONLY(), "\n" ;
-# print "O_WRONLY = ", O_WRONLY(), "\n" ;
-# print "O_APPEND = ", O_APPEND(), "\n" ;
-# print "O_CREAT   ", O_CREAT(), "\n" ;
-# print "O_EXCL   ", O_EXCL(), "\n" ;
-
-
 *slurp = \&read_file ;
 *rf = \&read_file ;
 

--- a/xt/author/pod_coverage.t
+++ b/xt/author/pod_coverage.t
@@ -2,22 +2,8 @@
 
 use Test::More;
 
-eval 'use Test::Pod::Coverage 1.04' ;
+eval 'use Test::Pod::Coverage 1.04';
 plan skip_all =>
-	'Test::Pod::Coverage 1.04 required for testing POD coverage' if $@ ;
+	'Test::Pod::Coverage 1.04 required for testing POD coverage' if $@;
 
-all_pod_coverage_ok(
-	{
-		trustme =>	[
-			'O_APPEND',
-			'O_BINARY',
-			'O_CREAT',
-			'O_EXCL',
-			'O_RDONLY',
-			'O_WRONLY',
-			'SEEK_CUR',
-			'SEEK_END',
-			'SEEK_SET',
-		],
-	}
-) ;
+all_pod_coverage_ok({ trustme => [], });


### PR DESCRIPTION
Prior to Perl 5.6, several functions may or may not be defined
based on which version/platform you were on. To work around this,
these functions were tested for and defined in a BEGIN {} block.

Since this is no longer necessary, we can safely remove this block
given that Perl 5.6 is a requirement for installation.

Also, update the xt/author tests to no longer ignore these
work-arounds in the pod coverage tests.