### PR TITLE
Add regression tests for GLOB references.

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Revision history File::Slurp
     - The previous release contained nothing but a documentation update. That
       updated documentation errantly mentioned pseudo-files. Pseudo-files
       are perfectly fine to use with File::Slurp.
+    - Add regression test for GLOB refs being slurped in. Thank you, James Keenan!
+      https://github.com/perhunter/slurp/pull/17#issuecomment-437174592
 
 9999.24     2018-10-29
     - Document the clear downfalls of using file handles of any kind rather

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ t/01-error_read_file.t
 t/01-error_write_file.t
 t/append_null.t
 t/binmode.t
+t/data_glob.t
 t/data_section.t
 t/edit_file.t
 t/error.t
@@ -27,6 +28,7 @@ t/inode.t
 t/large.t
 t/lib/FileSlurpTest.pm
 t/lib/FileSlurpTestOverride.pm
+t/lib/FSGlobby.pm
 t/newline.t
 t/no_clobber.t
 t/original.t

--- a/t/data_glob.t
+++ b/t/data_glob.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+use File::Basename ();
+use File::Spec ();
+use lib File::Spec->catdir(File::Spec->rel2abs(File::Basename::dirname(__FILE__)), 'lib');
+use FileSlurpTest qw(trap_function);
+use File::Slurp qw(read_file);
+
+# a package with a __DATA__ section
+use FSGlobby ();
+
+use Scalar::Util qw(blessed);
+use Symbol qw(qualify qualify_to_ref);
+use Test::More;
+
+plan tests => 9;
+
+my $obj = FSGlobby->new();
+ok(defined $obj, "Constructor returned defined object");
+isa_ok( $obj, 'FSGlobby');
+
+my $symbolname = qualify("DATA", blessed $obj);
+is($symbolname, 'FSGlobby::DATA', "Symbol::qualify(): Got expected symbol name");
+
+my $glob = qualify_to_ref("DATA", blessed $obj);
+is(ref($glob), 'GLOB', "Symbol::qualify_to_ref():  Got a glob");
+
+my @lines = read_file($glob, {chomp => 1});
+my $expected_lines = 8;
+is(scalar @lines, $expected_lines, "Got $expected_lines lines in file");
+is($lines[0], 'File:', "Got expected first line");
+is($lines[$expected_lines - 1], 'Last-Updated:', "Got expected last line");
+my %lines_seen;
+map { $lines_seen{$_}++ } @lines;
+is($lines_seen{$lines[0]}, 1, "First line seen exactly once");
+is($lines_seen{$lines[$expected_lines - 1]}, 1, "Last line seen exactly once");

--- a/t/lib/FSGlobby.pm
+++ b/t/lib/FSGlobby.pm
@@ -1,0 +1,18 @@
+package FSGlobby;
+
+sub new {
+    my $class = shift;
+    return bless {}, $class;
+}
+
+1;
+
+__DATA__
+File:
+URL:
+Description:
+Columns:
+Intended-For:
+Written-By:
+Line-Count:
+Last-Updated:


### PR DESCRIPTION
In smoke testing all reverse dependencies of File::Slurp for a
proposed fix to the sysopen/sysread problem on Perl 5.30, an error
came up with a particular dist that makes use of GLOB references.

James Keenan then researched a good test case for us. Thank you,
James for going through all of that effort:
https://github.com/perhunter/slurp/pull/17#issuecomment-437174592

For his efforts, we now have another test case that we can add to
the current test suite to prevent us from committing any
regressions into this distribution.

We can now work on fixing up the other pull request with a bit
more faith that we won't break userland.