### PR TITLE
Add test cases for the chomp option, fix for undef $/, improve some docs

### DIFF
--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -772,7 +772,7 @@ reference is followed by a comma.
 
 The next argument is the filename.
 
-The next argument(s) is either a hash reference or a flattened hash,
+The next argument is an optional hash reference of
 C<< key => value >> pairs. The options are passed through to the
 L<File::Slurp/"write_file"> function. All options are described there.
 Only the C<binmode> and C<err_mode> options are supported. The call to
@@ -799,7 +799,7 @@ code reference is followed by a comma.
 
 The next argument is the filename.
 
-The next argument(s) is either a hash reference or a flattened hash,
+The next argument is an optional hash reference of
 C<< key => value >> pairs. The options are passed through to the
 L<File::Slurp/"write_file"> function. All options are described there.
 Only the C<binmode> and C<err_mode> options are supported. The call to
@@ -859,7 +859,7 @@ C<write_file> with the new data and the existing file data.
 
 The first argument to C<prepend_file> is the filename.
 
-The next argument(s) is either a hash reference or a flattened hash,
+The next argument is an optional hash reference of
 C<< key => value >> pairs. The options are passed through to the
 L<File::Slurp/"write_file"> function. All options are described there.
 
@@ -1073,7 +1073,7 @@ an error. You can change how errors are handled with the C<err_mode> option.
 
 The first argument to C<write_file> is the filename.
 
-The next argument(s) is either a hash reference or a flattened hash,
+The next argument is an optional hash reference of
 C<< key => value >> pairs. The following options are available:
 
 =over

--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -124,10 +124,15 @@ sub read_file {
 	if ($want_array || $opts->{array_ref}) {
 		use re 'taint';
 		my $sep = $/;
-		$sep = '\n\n+' if defined $sep && $sep eq '';
-		# split the buffered content into lines
-		my @lines = length(${$buf_ref}) ?
-			${$buf_ref} =~ /(.*?$sep|.+)/sg : ();
+		my @lines;
+		if (defined $sep) {
+			$sep ='\n\n+' if $sep eq '';
+			@lines = length(${$buf_ref}) ?
+				${$buf_ref} =~ /(.*?$sep|.+)/sg : ();
+		}
+		else {
+			@lines = (${$buf_ref});
+		}
 		chomp @lines if $opts->{chomp};
 		return \@lines if $opts->{array_ref};
 		return @lines;
@@ -937,11 +942,16 @@ ensure the proper directory separator is used for your OS. See L<File::Spec>.
 	# or we can get a scalar reference
 	my $text_ref = read_file('/path/file', scalar_ref => 1);
 
-This function reads in an entire file and returns its contents to the
-caller. In scalar context it returns the entire file as a single
-scalar. In list context it will return a list of lines (using the
-current value of C<$/> as the separator, including support for paragraph
-mode when it is set to C<''>).
+This function reads in an entire file and returns its contents to the caller.
+In list context, or in scalar context with the C<array_ref> option set, it
+splits the contents using the current value of C<$/> as the separator.
+Paragraph mode, when C<$/> is set to C<''>, is supported. If C<$/> is undefined,
+then the first and only element of the list contains the entire file.  Reading
+fixed length records with C<$/> set to a reference to an integer is not
+supported.
+
+In scalar context with the C<array_ref> option set to false, it returns the
+contents of the entire file as a scalar value.
 
 The first argument is the path to the file to be slurped in.
 

--- a/t/option_chomp.t
+++ b/t/option_chomp.t
@@ -9,6 +9,7 @@ use FileSlurpTest qw(temp_file_path);
 
 use File::Slurp qw(read_file write_file);
 use Test::More;
+plan tests => 9;
 
 # -------- Prelude: Set up expected data and write a data file
 my $expected = <<TEXT;
@@ -84,8 +85,3 @@ my $file = temp_file_path();
 #     my $in_data = join '', @got;
 #     is($in_data,$expected,"fixed record mode, no chomping");
 # }
-
-
-
-
-done_testing;

--- a/t/option_chomp.t
+++ b/t/option_chomp.t
@@ -1,0 +1,91 @@
+# Purpose: Test the chomp option while reading files
+use strict;
+use warnings;
+
+use File::Basename ();
+use File::Spec ();
+use lib File::Spec->catdir(File::Spec->rel2abs(File::Basename::dirname(__FILE__)), 'lib');
+use FileSlurpTest qw(temp_file_path);
+
+use File::Slurp qw(read_file write_file);
+use Test::More;
+
+# -------- Prelude: Set up expected data and write a data file
+my $expected = <<TEXT;
+PREFACE
+
+All in the golden afternoon
+    Full leisurely we glide;
+For both our oars, with little skill,
+    By little arms are plied,
+While little hands make vain pretence
+    Our wanderings to guide.
+
+-- Lewis Carroll, Alice in Wonderland
+TEXT
+
+my @expected_lines = $expected =~ /(.*\n)/mg;
+chomp (my @expected_chomped = @expected_lines);
+
+my ($array_ref,$scalar_ref);
+
+my $file = temp_file_path();
+{
+    open my $fh, ">", $file or die "Couldn't open $file for write: $!";
+    $fh->print($expected);
+}
+
+# -------- Run the tests
+{
+    local $/ = 'a';
+    my $got = read_file($file, {chomp => 1});
+    is($got,$expected,"scalar context, no chomping");
+}
+
+{
+    my @got = read_file($file);
+    is_deeply(\@got,\@expected_lines, "list context, chomp not provided");
+}
+
+{
+    my @got = read_file($file, { chomp => 0 });
+    is_deeply(\@got,\@expected_lines, "list context, chomp => 0");
+}
+
+{
+    my @got = read_file($file, chomp => 1);
+    is_deeply(\@expected_chomped,\@got, "list context, chomp => 1, option as flat hash");
+}
+
+{
+    my @got = read_file($file, {chomp => 1});
+    is_deeply(\@expected_chomped,\@got, "list context, chomp => 1, option as hashref");
+}
+
+{
+    local $/ = '';
+    my @got = read_file($file, {chomp => 1});
+    is(scalar @got,3,"paragraph mode splits into three paragraphs");
+    isnt(substr($got[2],-1,1),"\n","paragraph mode chomps trailing line feed");
+}
+
+{
+    local $/;
+    my @got = read_file($file, {chomp => 1});
+    is(scalar @got,1,'slurp mode by undefined $/ yields one "line"');
+    is($got[0],$expected,"slurp mode by undefined \$/ doesn't chomp");
+}
+
+# read_file doesn't handle fixed record lengths
+# {
+#     local $/ = \24;
+#     my @got = read_file($file, {chomp => 0});
+#     is(scalar @got,10,"fixed record mode, ten paragraphs");
+#     my $in_data = join '', @got;
+#     is($in_data,$expected,"fixed record mode, no chomping");
+# }
+
+
+
+
+done_testing;


### PR DESCRIPTION
This is a pull request for the CPAN Pull Request Challenge.

The main plan was to add some tests for the chomp option of `read_file`, which are included.  But as ever so often, this lead to other discoveries...

`read_file` chomps the results only if they have been split into "lines" according to the current value of `$/`.  So I tried some possible values.

`read_file` has never worked when `$/` is undefined, where the split on an empty value would result in an array with two elements per character of input, every other of them undefined.  The PR changes this so that with undefined `$/`, the whole file content will be returned as the first and only element of the array.  The test cases no.8 and no.9 exercise that, and fail in the master branch.

Processing fixed length records with e.g. `$/ = \1024` doesn't work either, as it tries to split on a regex like `SCALAR(0x55c41c65fba0)`.  Apparently nobody has missed it so far, therefore in the current state of the PR I just added to the docs that it isn't supported.  If desired, I'd work on it - it isn't too difficult.

Finally, I fixed the docs where it states that the options can be given as a flattened hash, which isn't true for all of the writing operations.