### PR TITLE
Localize $^W to mitigate warnings from File::Temp.

### DIFF
--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -279,7 +279,10 @@ sub write_file {
 			}
 			# we must ensure we're using a good temporary filename (doesn't already
 			# exist). This is slower, but safer.
-			(undef, $file_name) = tempfile('tempXXXXX', DIR => $dir, OPEN => 0);
+			{
+				local $^W = 0; # AYFKM
+				(undef, $file_name) = tempfile('tempXXXXX', DIR => $dir, OPEN => 0);
+			}
 		}
 		$fh = local *FH;
 		unless (sysopen($fh, $file_name, $mode, $perms)) {


### PR DESCRIPTION
File::Temp's tempfile warns when you ask for an unopened temporary file
to let you know that it might not be the safest option because the
library itself can't guarantee that another process won't pick that
filename prior to you opening the file yourself.

This presents a problem if the user runs their app with the -w flag
since we need to open the file ourselves to deal with file permissions
on the open process so we adhere to both the filesystem's potential ACL
settings as well as the original file's permission set.

This local $^W fix prevents the warning we know about from bothering the
end user as it's not a warning they should be concerned about as we are
dealing with it in File::Slurp.