### PR TITLE
write_file: fsync() before renaming the file in atomic mode

### DIFF
--- a/lib/File/Slurp.pm
+++ b/lib/File/Slurp.pm
@@ -325,12 +325,27 @@ sub write_file {
 	seek($fh, 0, SEEK_END) if $opts->{append};
 	print {$fh} ${$buf_ref};
 	truncate($fh, tell($fh)) unless $no_truncate;
-	close($fh);
 
-	if ($opts->{atomic} && !rename($file_name, $orig_filename)) {
+	if (
+		$opts->{atomic}
+		&& (
+			!$fh->flush()
+			# We must sync in atomic mode such that the write hits the disk before the
+			# rename happens. Otherwise you can run into a situation where the rename
+			# metadata operation commits before the data write operation. If the
+			# latter then fails to commit due to i.e. a full filesystem, this would
+			# leave you with an empty file at the desired location rather than either
+			# the previous content or the new content, breaking the promise of
+			# atomicity.
+			|| !$fh->sync()
+			|| !rename($file_name, $orig_filename)
+		)
+	) {
+		close($fh);
 		@_ = ($opts, "write_file '$file_name' - rename: $!");
 		goto &_error;
 	}
+	close($fh);
 
 	return 1;
 }


### PR DESCRIPTION
This was noticed when a btrfs went out of space while the NixOS activation
script attempted to write the UID map file. It left an empty file on disk,
destroying an integral piece of state which then caused the system to fail
booting because the content was not valid JSON.

I cannot verify whether this patch fixes that issue in particular because it is
hard to reproduce. The previous behaviour is wrong in even just theory though as
there is no guarantee that the content write and rename happen in the same
transaction AFAICT.

The code now explicitly waits for the content to have hit the disk before
renaming. I've verified that the order of syscalls as observed by `strace` is
correct.
